### PR TITLE
Fix the anchor link of C++

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Blog Aggregator](#blog-aggregator)
 - [Brain Computer Interface](#brain-computer-interface)
 - [C](#c)
-- [C++](#c++)
+- [C++](#c-1)
 - [Clojure](#clojure)
 - [Company Blogs](#company-blogs)
 - [Compilers](#compilers)


### PR DESCRIPTION
Github does not support special characters in the anchor link. According to the conversion rules, the anchor link of `C++` will become `c-1`.